### PR TITLE
fix: update Docker base image to eclipse-temurin for Java services

### DIFF
--- a/discovery-service/Dockerfile
+++ b/discovery-service/Dockerfile
@@ -1,5 +1,5 @@
 # discovery-service/Dockerfile
-FROM openjdk:17-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 ENV APP_FILE discovery-Service-1.1-SNAPSHOT.jar
 ENV APP_HOME /app
 EXPOSE 8761

--- a/gateway-service/Dockerfile
+++ b/gateway-service/Dockerfile
@@ -1,5 +1,5 @@
 # gateway-service/Dockerfile
-FROM openjdk:17-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 ENV APP_FILE gateway-service-0.0.1-SNAPSHOT.jar
 ENV APP_HOME /app
 EXPOSE 8060


### PR DESCRIPTION
- Replaced deprecated openjdk:17-jre-alpine image with eclipse-temurin:17-jre-alpine in Java-based service Dockerfiles.